### PR TITLE
Add `--no-cache` + envvar support for make docker-build(-all) targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ SHOW:=@echo
 # use HIDE to run commands invisibly, unless VERBOSE defined
 HIDE:=$(if $(VERBOSE),,@)
 
+# Invoking `NO_CACHE=1 make docker-build` will cause containers to be built
+# from scratch (as we do in CI) but will take considerably longer to complete;
+# by default we skip this option for local development as a convenience
+ifdef NO_CACHE
+NO_CACHE="--no-cache"
+endif
+
 # Our applications recognize this as the top directory for the project, and look for files there
 # at runtime, e.g. for configuration.
 export ALACRIS_HOME:=$(shell pwd)
@@ -266,7 +273,7 @@ docker-build-all:
 	$(HIDE) docker/scripts/build_all_images.sh
 
 docker-build: ## Build all or c=<name> containers in foreground
-	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) build $(c)
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) build $(NO_CACHE) $(c)
 
 docker-list: ## List available services
 	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) config --services

--- a/docker/scripts/build_all_images.sh
+++ b/docker/scripts/build_all_images.sh
@@ -14,13 +14,22 @@ run() {
 }
 
 echo "Building build prerequisite image"
-run docker build -t gcr.io/legicash-demo-1950/legicash-demo/build-prerequisites:v1 -f docker/containers/build-prerequisites/Dockerfile .
+run docker build \
+  --no-cache \
+  -t gcr.io/legicash-demo-1950/legicash-demo/build-prerequisites:v1 \
+  -f docker/containers/build-prerequisites/Dockerfile .
 
 echo "Building client runtime prerequisite image"
-run docker build -t gcr.io/legicash-demo-1950/legicash-demo/alacris_client_container:v1 -f docker/containers/alacris_client_container/Dockerfile .
+run docker build \
+  --no-cache \
+  -t gcr.io/legicash-demo-1950/legicash-demo/alacris_client_container:v1 \
+  -f docker/containers/alacris_client_container/Dockerfile .
 
 echo "Building side chain manager runtime prerequisite image"
-run docker build -t gcr.io/legicash-demo-1950/legicash-demo/alacris_side_chain_manager_container:v1 -f docker/containers/alacris_side_chain_manager_container/Dockerfile .
+run docker build \
+  --no-cache \
+  -t gcr.io/legicash-demo-1950/legicash-demo/alacris_side_chain_manager_container:v1 \
+  -f docker/containers/alacris_side_chain_manager_container/Dockerfile .
 
 echo "Cleanup of state and log directories"
 [ -d /tmp/legilogs ] && run rm -rf /tmp/legilogs || true
@@ -32,4 +41,4 @@ echo "Seting permissions"
 run chmod -R a+rwX /tmp/legilogs
 
 echo "Building application images"
-run docker-compose -f docker/docker-compose.yml build
+run docker-compose -f docker/docker-compose.yml build --no-cache


### PR DESCRIPTION
`NO_CACHE=1 make docker-build` will be useful mostly for continuous integration and can be entirely ignored during local development.

Thanks @vlebo for doing the actual work.